### PR TITLE
added comment

### DIFF
--- a/test.html
+++ b/test.html
@@ -15,14 +15,14 @@
     <div>
         <h1>Here's a big div to test some multiline comment diffing for github</h1>
 
-        <div>
+        <!-- <div>
             <ul>
                 <li>1</li>
                 <li>2</li>
                 <li>3</li>
             </ul>
             <img src="https://cdn.pixabay.com/photo/2014/12/22/00/07/tree-576847__480.png" alt="tree">
-        </div>
+        </div> -->
     </div>
 
     <script src='https://cdn.jsdelivr.net/npm/vue@2.6.12/dist/vue.js'></script>


### PR DESCRIPTION
As you can see, the github diff for HTML comments is rendered in correctly in the previous state. It colors it as commented code, when it was not commented. This caused some confusion for me in a different project, so here is a minimal reproduction.